### PR TITLE
#276 : Basic-Auth support for policyLocation

### DIFF
--- a/agent/core/src/test/java/org/jolokia/restrictor/RestrictorFactoryTest.java
+++ b/agent/core/src/test/java/org/jolokia/restrictor/RestrictorFactoryTest.java
@@ -2,7 +2,9 @@ package org.jolokia.restrictor;
 
 import org.jolokia.config.ConfigKey;
 import org.jolokia.config.Configuration;
+import org.jolokia.restrictor.RestrictorFactory.URLConnectionResult;
 import org.jolokia.util.LogHandler;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -54,6 +56,35 @@ public class RestrictorFactoryTest {
 
     }
 
+    @DataProvider(name = "basicAuthTestDataProvider")
+    private static Object[][] provideBasicAuthData() {
+
+        return new Object[][] {
+                { "file:///some.file", "file:///some.file", null }, //
+                { "http://host", "http://host", null }, //
+                { "http://some.host", "http://some.host", null }, //
+                { "http://some.host.com", "http://some.host.com", null }, //
+                { "https://some.ho-st.com", "https://some.ho-st.com", null }, //
+                { "http://user:@some.host.com", "http://user:@some.host.com", null }, //
+                { "http://user:pass@some.host.com", "http://some.host.com", "Basic dXNlcjpwYXNz" }, //
+                { "http://:pass@some.host.com", "http://:pass@some.host.com", null }, //
+                { "http://user:pass@host", "http://host", "Basic dXNlcjpwYXNz" }, //
+                { "https://user:pass@host", "https://host", "Basic dXNlcjpwYXNz" }, //
+                { "https://user:pass@host:1234", "https://host:1234", "Basic dXNlcjpwYXNz" } //
+        };
+
+    }
+
+    @Test(dataProvider = "basicAuthTestDataProvider")
+    public void testUrlConnectionBuilder(String pLocation,
+            String expectedUrl, String expectedBasicAuthHeaderValue) throws Exception {
+
+        URLConnectionResult result = RestrictorFactory.buildUrlConnection(pLocation);
+        assertNotNull(result.urlConnection);
+        assertEquals(expectedUrl, result.url);
+        assertEquals(expectedBasicAuthHeaderValue, result.basicAuthHeaderValue);
+
+    }
 
     private Configuration getConfig(Object... extra) {
         ArrayList list = new ArrayList();


### PR DESCRIPTION
This took a little longer due to other work related tasks...

Ideally I'd have wanted to build a separate "UrlBuilder" unit but that would have also meant providing it to another package private factory method for unit testing it's orchestration. Thought it was too much overhead and skipped that.
- A `rawLocation` had to be introduced in order to not print out the env-interpolated URL.
- Also testing URLConnection for presence of the header field is tricky as the `Authorization` header is regared secure by the Sun implementation and thus not returned on query. That's why the URL building return object which is primarily used for the tests.

I've likely broken a dozen style guidelines as well. Not sure I've been creative enough regarding the unit test URLs.
