### PR TITLE
#439 HTTP_bind_by_NIC_interfacename

### DIFF
--- a/agent/core/src/main/java/org/jolokia/config/address/AddressConfigService.java
+++ b/agent/core/src/main/java/org/jolokia/config/address/AddressConfigService.java
@@ -1,0 +1,47 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Service to obtain an {@link InetAddress} to bind the <em>Jolokia</em> service
+ * to.
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ *
+ */
+public interface AddressConfigService {
+
+    /**
+     * Optain an address regarding multiple configuration items.
+     * 
+     * @param agentConfig map holding the configuration in string representation.
+     * @return An reference to an address. The reference is <code>null</code> if no
+     *         address could be optained from configuration. Then the callee should
+     *         bind to all available ip addresses. It is alowed to return an empty
+     *         reference to signal the same. The Reference is used to substitute an
+     *         Optional wich isn't available in Java 6.
+     * @throws RuntimeException If the configuration is invalid.
+     */
+    public AtomicReference<InetAddress> optain(Map<String, String> agentConfig) throws RuntimeException;
+
+}

--- a/agent/core/src/main/java/org/jolokia/config/address/DelegatingAddressConfigService.java
+++ b/agent/core/src/main/java/org/jolokia/config/address/DelegatingAddressConfigService.java
@@ -1,0 +1,73 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Delegating {@link AddressConfigService} wicht iterates over multiple service
+ * to optain an valid {@link InetAddress} to bind the <em>Jolokia</em> service
+ * to.
+ * 
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ */
+public class DelegatingAddressConfigService implements AddressConfigService {
+
+	private final List<AddressConfigService> services;
+
+	/**
+	 * Konstructor
+	 */
+	public DelegatingAddressConfigService() {
+		super();
+
+		this.services = Collections.unmodifiableList(Arrays.asList(new AddressConfigService[] {
+				new DirectAddressConfigService(), new IPMatchingConfigService(), new NICMatchingConfigService() }));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public AtomicReference<InetAddress> optain(Map<String, String> agentConfig) {
+		final Iterator<AddressConfigService> iterator = this.services.iterator();
+
+		while (iterator.hasNext()) {
+			AtomicReference<InetAddress> result = iterator.next().optain(agentConfig);
+
+			if (null != result) {
+				return result;
+			}
+		}
+
+		try {
+			return new AtomicReference<InetAddress>(InetAddress.getByName(null));
+		} catch (final UnknownHostException exception) {
+			throw new IllegalArgumentException("Can not lookup loopback interface", exception);
+		}
+	}
+}

--- a/agent/core/src/main/java/org/jolokia/config/address/DirectAddressConfigService.java
+++ b/agent/core/src/main/java/org/jolokia/config/address/DirectAddressConfigService.java
@@ -1,0 +1,61 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Direct service using the {@value #CONFIG_KEY} configuration to optain an
+ * {@link InetAddress}
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ */
+public class DirectAddressConfigService implements AddressConfigService {
+
+    static final String CONFIG_KEY = "host";
+    
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public final AtomicReference<InetAddress> optain(final Map<String, String> agentConfig) {
+		final String host = agentConfig.get(CONFIG_KEY);
+
+		if (agentConfig.containsKey(CONFIG_KEY)) {
+		    // Mark responsibility to the callee
+			final AtomicReference<InetAddress> result = new AtomicReference<InetAddress>();
+			try {
+				if ("*".equals(host) || "0.0.0.0".equals(host)) {
+					return result; // null is the wildcard
+				} else {
+					result.set(InetAddress.getByName(host)); // some specific host
+				}
+			} catch (UnknownHostException e) {
+				throw new IllegalArgumentException(
+						"Can not lookup " + (host != null ? host : "loopback interface") + ": " + e, e);
+			}
+			return result;
+		}
+		return null;
+	}
+
+}

--- a/agent/core/src/main/java/org/jolokia/config/address/IPMatchingConfigService.java
+++ b/agent/core/src/main/java/org/jolokia/config/address/IPMatchingConfigService.java
@@ -1,0 +1,90 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This service using the {@value #CONFIG_KEY} configuration to optain an
+ * {@link InetAddress} from an matching network ip address
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ *
+ */
+public class IPMatchingConfigService implements AddressConfigService {
+
+    static final String CONFIG_KEY = "ipmatch";
+    private static final String ERROR_APPLY_PATTERN = "Error seeking IP with pattern: '%02$s' from config: '%01$s'.";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final AtomicReference<InetAddress> optain(final Map<String, String> agentConfig) throws RuntimeException {
+
+        if (agentConfig.containsKey(CONFIG_KEY)) {
+            final String value = agentConfig.get(CONFIG_KEY);
+
+            // Mark responsibility to the callee
+            final AtomicReference<InetAddress> result = new AtomicReference<InetAddress>();
+
+            try {
+                if (null != value) {
+                    final Pattern matchPattern = Pattern.compile(value);
+
+                    Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
+
+                    while (nets.hasMoreElements()) {
+                        final NetworkInterface netIF = nets.nextElement();
+                        final Enumeration<InetAddress> addresses = netIF.getInetAddresses();
+
+                        while (addresses.hasMoreElements()) {
+                            final InetAddress address = addresses.nextElement();
+                            if (matchPattern.matcher(address.getHostAddress()).matches()) {
+                                result.set(address);
+                                return result;
+                            }
+                        }
+                    }
+                }
+            } catch (final Throwable exception) {
+                throw new IllegalArgumentException(String.format(ERROR_APPLY_PATTERN, CONFIG_KEY, value), exception);
+            } finally {
+                // // secure alternative -- if no host, use *loopback*
+                if (null == result.get()) {
+                    try {
+                        result.set(InetAddress.getByName(null));
+                    } catch (final UnknownHostException exception) {
+                        throw new IllegalArgumentException("Can not lookup loopback interface", exception);
+                    }
+                }
+            }
+
+            return result;
+        }
+        return null;
+    }
+
+}

--- a/agent/core/src/main/java/org/jolokia/config/address/NICMatchingConfigService.java
+++ b/agent/core/src/main/java/org/jolokia/config/address/NICMatchingConfigService.java
@@ -1,0 +1,94 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This service using the {@value #CONFIG_KEY} configuration to optain an
+ * {@link InetAddress} from an matching network interfacename
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ *
+ */
+public class NICMatchingConfigService implements AddressConfigService {
+
+    static final String CONFIG_KEY = "nicmatch";
+    private static final String ERROR_APPLY_PATTERN = "Error configure IP by NIC name with pattern: '%02$s' from config: '%01$s'.";
+
+    /**
+     * Default Constructor
+     */
+    public NICMatchingConfigService() {
+        super();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final AtomicReference<InetAddress> optain(final Map<String, String> agentConfig) throws RuntimeException {
+
+        if (agentConfig.containsKey(CONFIG_KEY)) {
+            // Mark responsibility to the callee
+            final AtomicReference<InetAddress> result = new AtomicReference<InetAddress>();
+            final String value = agentConfig.get(CONFIG_KEY);
+
+            try {
+                if (null != value) {
+                    final Pattern matchPattern = Pattern.compile(value);
+
+                    Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
+
+                    while (nets.hasMoreElements()) {
+                        final NetworkInterface netIF = nets.nextElement();
+
+                        if (matchPattern.matcher(netIF.getName()).matches()) {
+                            final Enumeration<InetAddress> addresses = netIF.getInetAddresses();
+
+                            if (addresses.hasMoreElements()) {
+                                result.set(addresses.nextElement());
+                                return result;
+                            }
+                        }
+                    }
+                }
+            } catch (final Throwable exception) {
+                throw new IllegalArgumentException(String.format(ERROR_APPLY_PATTERN, CONFIG_KEY, value), exception);
+            } finally {
+                // // secure alternative -- if no host, use *loopback*
+                if (null == result.get()) {
+                    try {
+                        result.set(InetAddress.getByName(null));
+                    } catch (final UnknownHostException exception) {
+                        throw new IllegalArgumentException("Can not lookup loopback interface", exception);
+                    }
+                }
+            }
+            return result;
+        }
+        return null;
+    }
+}

--- a/agent/core/src/test/java/org/jolokia/config/address/AddressConfigServiceTstBase.java
+++ b/agent/core/src/test/java/org/jolokia/config/address/AddressConfigServiceTstBase.java
@@ -1,0 +1,104 @@
+package org.jolokia.config.address;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Basic testing functions for Implementations of {@link AddressConfigService}
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ *
+ */
+public abstract class AddressConfigServiceTstBase {
+
+    public static final String ASSERT_NOTNULL_REF = "The returned reference should not be null.";
+    public static final String ASSERT_NULL_REF = "The returned reference should be null.";
+    
+    /**
+     * Bad Reg-Ex-Pattern: Unclosed Group
+     */
+    public static final String PATTERN_BAD = "(.*";
+    /**
+     * Pattern that should not match any NicName
+     */
+    public static final String PATTERN_NEVERLAND = "\\W{666}";
+    
+    /**
+     * Lookup the first Interface having a name and an ip address.
+     * 
+     * @return The interface. There should be one at least nowadays.
+     * @throws SocketException If something went wrong.
+     */
+    public NetworkInterface getFirstNamedInterfaceWithIP() throws SocketException {
+
+        Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
+
+        while (nics.hasMoreElements()) {
+            NetworkInterface nic = nics.nextElement();
+
+            if (null != nic.getName() && nic.getName().length() > 0) {
+                Enumeration<InetAddress> addresses = nic.getInetAddresses();
+
+                while (addresses.hasMoreElements()) {
+                    return nic;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Lookup the first ip address.
+     * 
+     * @return The ip. There should be one at least nowadays.
+     * @throws SocketException If something went wrong.
+     */
+    public InetAddress getInterfaceIP() throws SocketException {
+
+        Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
+
+        while (nics.hasMoreElements()) {
+            NetworkInterface nic = nics.nextElement();
+
+            if (null != nic.getName() && nic.getName().length() > 0) {
+                Enumeration<InetAddress> addresses = nic.getInetAddresses();
+
+                while (addresses.hasMoreElements()) {
+                    return addresses.nextElement();
+                }
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Create a new configuration.
+     * 
+     * @return The configuration.
+     */
+    public Map<String, String> newAgentConfig() {
+        return new HashMap<String, String>();
+    }
+}

--- a/agent/core/src/test/java/org/jolokia/config/address/DelegatingAddressConfigServiceTest.java
+++ b/agent/core/src/test/java/org/jolokia/config/address/DelegatingAddressConfigServiceTest.java
@@ -1,0 +1,107 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Testing the {@link DelegatingAddressConfigService}
+ * 
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ */
+public class DelegatingAddressConfigServiceTest extends AddressConfigServiceTstBase {
+
+    /**
+     * Testing the Service if none delegates service is configured
+     * @throws UnknownHostException 
+     */
+    @Test
+    public void unconfigured() throws  UnknownHostException {
+        DelegatingAddressConfigService service = new DelegatingAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+
+        agentConfig.clear();
+
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), InetAddress.getByName(null));
+    }
+
+    /**
+     * Testing the Service if none delegates service is configured
+     */
+    @Test
+    public void direct_wildcard() {
+        DelegatingAddressConfigService service = new DelegatingAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, "*");
+
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertNull(result.get(), ASSERT_NULL_REF);
+    }
+
+    /**
+     * Testing the Service prefers an configured
+     * {@linkplain DirectAddressConfigService} instead of an greedy
+     * {@link NICMatchingConfigService}
+     */
+    @Test
+    public void prefer_Host_NINMatch() {
+        DelegatingAddressConfigService service = new DelegatingAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, "*");
+        agentConfig.put(NICMatchingConfigService.CONFIG_KEY, ".*");
+
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertNull(result.get(), ASSERT_NULL_REF);
+    }
+    
+    /**
+     * Testing the Service prefers an configured
+     * {@linkplain DirectAddressConfigService} instead of an greedy
+     * {@link NICMatchingConfigService}
+     */
+    @Test
+    public void prefer_Host_IPMatch() {
+        DelegatingAddressConfigService service = new DelegatingAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, "*");
+        agentConfig.put(IPMatchingConfigService.CONFIG_KEY, ".*");
+
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertNull(result.get(), ASSERT_NULL_REF);
+    }
+
+}

--- a/agent/core/src/test/java/org/jolokia/config/address/DirectAddressConfigServiceTest.java
+++ b/agent/core/src/test/java/org/jolokia/config/address/DirectAddressConfigServiceTest.java
@@ -1,0 +1,176 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Testing {@link DirectAddressConfigService}
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ *
+ */
+public class DirectAddressConfigServiceTest extends AddressConfigServiceTstBase {
+    
+    /**
+     * Test the behavior if configuring an invalid regular expression.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badPattern() {
+        DirectAddressConfigService service = new DirectAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, PATTERN_BAD );
+        service.optain(agentConfig );
+    }
+
+    
+    /**
+     * Test the behavior if the service configuration contains an empty string.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void empty_EMPTY() throws SocketException, UnknownHostException {
+        DirectAddressConfigService service = new DirectAddressConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, "");
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+    
+    /**
+     * Test the behavior if the service configuration contains <code>null</code> value.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void empty_NULL() throws SocketException, UnknownHostException {
+        DirectAddressConfigService service = new DirectAddressConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, null);
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+    
+    /**
+     * Test the behavior if configuring an invalid regular expression.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     */
+    @Test()
+    public void matching_IP() throws SocketException {
+        InetAddress refIP = this.getInterfaceIP();
+        
+        DirectAddressConfigService service = new DirectAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, refIP.getHostAddress() );
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), refIP);
+    }
+    
+    /**
+     * Test the behavior if matching all IPs by wildcard.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     */
+    @Test()
+    public void matching_Wildcard_Asterix() throws SocketException {
+        DirectAddressConfigService service = new DirectAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, "*" );
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertNull(result.get(), ASSERT_NULL_REF);
+    }
+    
+    /**
+     * Test the behavior if matching all IPs by wildcard.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     */
+    @Test()
+    public void matching_Wildcard_Zeros() throws SocketException {
+        DirectAddressConfigService service = new DirectAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, "0.0.0.0" );
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertNull(result.get(), ASSERT_NULL_REF);
+    }
+    
+    /**
+     * Test the behavior if configuring a matcher that do not find a IP.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void nonMatching() throws SocketException, UnknownHostException {
+        DirectAddressConfigService service = new DirectAddressConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(DirectAddressConfigService.CONFIG_KEY, "999.999.999.999" );
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+    
+    /**
+     * Test the behavior if the service is not configured.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void notConfigured() throws SocketException, UnknownHostException {
+        DirectAddressConfigService service = new DirectAddressConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.remove(DirectAddressConfigService.CONFIG_KEY);
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        Assert.assertNull(result, ASSERT_NULL_REF);
+    }
+}

--- a/agent/core/src/test/java/org/jolokia/config/address/IPMatchingConfigServiceTest.java
+++ b/agent/core/src/test/java/org/jolokia/config/address/IPMatchingConfigServiceTest.java
@@ -1,0 +1,145 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Testing {@link IPMatchingConfigService}
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ *
+ */
+public class IPMatchingConfigServiceTest extends AddressConfigServiceTstBase {
+    
+    /**
+     * Test the behavior if configuring an invalid regular expression.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badPattern() {
+        IPMatchingConfigService service = new IPMatchingConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(IPMatchingConfigService.CONFIG_KEY, PATTERN_BAD );
+        service.optain(agentConfig );
+    }
+
+    
+    /**
+     * Test the behavior if the service configuration contains an empty string.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void empty_EMPTY() throws SocketException, UnknownHostException {
+        IPMatchingConfigService service = new IPMatchingConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(IPMatchingConfigService.CONFIG_KEY, "");
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+    
+    /**
+     * Test the behavior if the service configuration contains <code>null</code> value.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void empty_NULL() throws SocketException, UnknownHostException {
+        IPMatchingConfigService service = new IPMatchingConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(IPMatchingConfigService.CONFIG_KEY, null);
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+    
+    /**
+     * Test the behavior if configuring an invalid regular expression.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     */
+    @Test()
+    public void matching() throws SocketException {
+        InetAddress refIP = this.getInterfaceIP();
+        
+        IPMatchingConfigService service = new IPMatchingConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(IPMatchingConfigService.CONFIG_KEY, Pattern.quote(refIP.getHostAddress()) );
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), refIP);
+    }
+
+
+    /**
+     * Test the behavior if configuring a matcher that do not find a IP.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void nonMatching() throws SocketException, UnknownHostException {
+        IPMatchingConfigService service = new IPMatchingConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(IPMatchingConfigService.CONFIG_KEY, PATTERN_NEVERLAND );
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+
+
+    /**
+     * Test the behavior if the service is not configured.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void notConfigured() throws SocketException, UnknownHostException {
+        IPMatchingConfigService service = new IPMatchingConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.remove(IPMatchingConfigService.CONFIG_KEY);
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        Assert.assertNull(result, ASSERT_NULL_REF);
+    }
+}

--- a/agent/core/src/test/java/org/jolokia/config/address/NICMatchingConestfigServiceTest.java
+++ b/agent/core/src/test/java/org/jolokia/config/address/NICMatchingConestfigServiceTest.java
@@ -1,0 +1,147 @@
+package org.jolokia.config.address;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * 
+ * Copyright 2020 Georg Tsakumagos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Testing {@link NICMatchingConfigService}
+ * 
+ * @author Georg Tsakumagos
+ * @since 21.06.2020
+ *
+ */
+public class NICMatchingConestfigServiceTest extends AddressConfigServiceTstBase {
+    
+    /**
+     * Test the behavior if configuring an invalid regular expression.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badPattern() {
+        NICMatchingConfigService service = new NICMatchingConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(NICMatchingConfigService.CONFIG_KEY, PATTERN_BAD );
+        service.optain(agentConfig );
+    }
+
+    
+    /**
+     * Test the behavior if the service configuration contains an empty string.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void empty_EMPTY() throws SocketException, UnknownHostException {
+        NICMatchingConfigService service = new NICMatchingConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(NICMatchingConfigService.CONFIG_KEY, "");
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+    
+    /**
+     * Test the behavior if the service configuration contains <code>null</code> value.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void empty_NULL() throws SocketException, UnknownHostException {
+        NICMatchingConfigService service = new NICMatchingConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(NICMatchingConfigService.CONFIG_KEY, null);
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+    
+    /**
+     * Test the behavior if configuring an invalid regular expression.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     */
+    @Test()
+    public void matching() throws SocketException {
+        NetworkInterface refNic = this.getFirstNamedInterfaceWithIP();
+        
+        NICMatchingConfigService service = new NICMatchingConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(NICMatchingConfigService.CONFIG_KEY, Pattern.quote(refNic.getName()) );
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertTrue(Collections.list(refNic.getInetAddresses()).contains(result.get()));
+    }
+
+
+    /**
+     * Test the behavior if configuring an invalid regular expression.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void nonMatching() throws SocketException, UnknownHostException {
+        NICMatchingConfigService service = new NICMatchingConfigService();
+        InetAddress loopback = InetAddress.getByName(null);
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.put(NICMatchingConfigService.CONFIG_KEY, PATTERN_NEVERLAND );
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        
+        Assert.assertNotNull(result, ASSERT_NOTNULL_REF);
+        Assert.assertEquals(result.get(), loopback);
+    }
+
+
+    /**
+     * Test the behavior if the service is not configured.
+     * @throws SocketException If something went wrong enumerate the local interfaces.
+     * @throws UnknownHostException If resvoling loopback interface fail.
+     */
+    @Test()
+    public void notConfigured() throws SocketException, UnknownHostException {
+        NICMatchingConfigService service = new NICMatchingConfigService();
+        Map<String, String> agentConfig = newAgentConfig();
+        
+        agentConfig.remove(NICMatchingConfigService.CONFIG_KEY);
+        
+        AtomicReference<InetAddress> result = service.optain(agentConfig);
+        Assert.assertNull(result, ASSERT_NULL_REF);
+    }
+}

--- a/src/docbkx/agents/jvm.xml
+++ b/src/docbkx/agents/jvm.xml
@@ -114,12 +114,37 @@ java -javaagent:agent.jar=port=7777,host=localhost]]></programlisting>
         <td><constant>host</constant></td>
         <td>
           Hostaddress to which the HTTP server should bind to. If "*" or "0.0.0.0" is
-          given, the servers binds to every network interface.
+          given, the servers binds to every network interface. This setting is mutually exclusive to <em>ipmatch</em> and <em>nicmatch</em>. 
+          Do not combine this settings. Bad configuration or errors resolving network informations will fallback to loopback interface for security reasons.
         </td>
         <td>
           <constant>localhost</constant>
         </td>
         </tr>
+        <tr>
+        <td><constant>ipmatch</constant></td>
+        <td>
+          Indirect configuration of Hostaddress to which the HTTP server should bind to. 
+          The IP address string in textual presentation of all available network interfaces will be 
+          checked against this Java regular expression. The first matching IP will be used to bind the HTTP server.
+		  Bad configuration or errors resolving network informations will fallback to loopback interface for security reasons.
+        </td>
+        <td>
+          <constant>192\.168\.1\..*</constant>
+        </td>
+        </tr>        
+        <tr>
+        <td><constant>nicmatch</constant></td>
+        <td>
+          Indirect configuration of Hostaddress to which the HTTP server should bind to. 
+          The name of all available network interfaces will be checked against this Java regular expression.
+          If the pattern matches the first IP of that interface will be used to bind the HTTP server.
+		  Bad configuration or errors resolving network informations will fallback to loopback interface for security reasons.
+        </td>
+        <td>
+          <constant>ethMonitoring</constant>
+        </td>
+        </tr> 
         <tr>
           <td><constant>port</constant></td>
           <td>


### PR DESCRIPTION
- Delegate address resolving to an global service
- Added service for RegEx matching on IPs
- Added service for RegEx matching on interface names
- Extend DocBook for jvm-agent config