### PR TITLE
Unblock building with Maven 3.8.1

### DIFF
--- a/agent/jvm/pom.xml
+++ b/agent/jvm/pom.xml
@@ -96,8 +96,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 

--- a/it/core/pom.xml
+++ b/it/core/pom.xml
@@ -52,8 +52,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
           </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <meminitial>128m</meminitial>
           <maxmem>512m</maxmem>
         </configuration>


### PR DESCRIPTION
Bumps source/target versions of `maven-compiler-plugin` from `1.6` to `1.7`, as `1.6` is no longer supported.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>