### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/agent/jvm/pom.xml
+++ b/agent/jvm/pom.xml
@@ -153,7 +153,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <!--<argLine>-Djava.security.debug=certpath,Provider</argLine>-->
         </configuration>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
