### PR TITLE
chore(ci): add Java 17 to CI matrix #524

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Relates #524

Unfortunately `setup-java` doesn't seem to support Java versions prior to 8, so we can only add 17 to the matrix.
https://github.com/actions/setup-java#supported-version-syntax