### PR TITLE
Remove jQuery: $.extend

### DIFF
--- a/client/javascript/src/main/javascript/jolokia-simple.js
+++ b/client/javascript/src/main/javascript/jolokia-simple.js
@@ -32,31 +32,23 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
         // AMD. Register as an anonymous module.
-        define(["jquery", "./jolokia"], factory);
+        define(["./jolokia"], factory);
     } else if (typeof module === "object" && module.exports) {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
         // like Node.
-        var jquery = require("jquery");
-        // To get along with jest-environment-jsdom
-        if (typeof jquery.fn !== "undefined") {
-            module.exports = factory(jquery, require("./jolokia"));
-        } else {
-            var jsdom = require("jsdom");
-            var dom = new jsdom.JSDOM("");
-            module.exports = factory(jquery(dom.window), require("./jolokia"));
-        }
+        module.exports = factory(require("./jolokia"));
     } else {
         // Browser globals
         if (root.Jolokia) {
-            factory(root.jQuery, root.Jolokia);
+            factory(root.Jolokia);
         } else {
             console.error("No Jolokia definition found. Please include jolokia.js before jolokia-simple.js");
         }
     }
-}(typeof self !== "undefined" ? self : this, function (jQuery, Jolokia) {
+}(typeof self !== "undefined" ? self : this, function (Jolokia) {
 
-    var builder = function($,Jolokia) {
+    var builder = function(Jolokia) {
         /**
          * Get one or more attributes
          *
@@ -275,7 +267,7 @@
         // Prepare callback to receive directly the value (instead of the full blown response)
         function prepareSuccessCallback(opts) {
             if (opts && opts.success) {
-                var parm = $.extend({},opts);
+                var parm = Jolokia.assignObject({}, opts);
                 parm.success = function(resp) {
                     opts.success(resp.value);
                 };
@@ -290,7 +282,7 @@
         }
 
         // Extend the Jolokia prototype with new functionality (mixin)
-        $.extend(Jolokia.prototype,
+        Jolokia.assignObject(Jolokia.prototype,
                 {
                     "getAttribute" : getAttribute,
                     "setAttribute" : setAttribute,
@@ -302,5 +294,5 @@
         return Jolokia;
     };
 
-    return builder(jQuery, Jolokia);
+    return builder(Jolokia);
 }));

--- a/client/javascript/src/main/javascript/jolokia.js
+++ b/client/javascript/src/main/javascript/jolokia.js
@@ -109,7 +109,7 @@
             if (typeof param === "string") {
                 param = {url:param};
             }
-            $.extend(agentOptions, DEFAULT_CLIENT_PARAMS, param);
+            Jolokia.assignObject(agentOptions, DEFAULT_CLIENT_PARAMS, param);
 
             // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
             // Public methods
@@ -230,11 +230,11 @@
                 }
 
                 if (extractMethod(request, opts) === "post") {
-                    $.extend(ajaxParams, POST_AJAX_PARAMS);
+                    Jolokia.assignObject(ajaxParams, POST_AJAX_PARAMS);
                     ajaxParams.data = JSON.stringify(request);
                     ajaxParams.url = ensureTrailingSlash(opts.url);
                 } else {
-                    $.extend(ajaxParams, GET_AJAX_PARAMS);
+                    Jolokia.assignObject(ajaxParams, GET_AJAX_PARAMS);
                     ajaxParams.dataType = opts.jsonp ? "jsonp" : "json";
                     ajaxParams.url = opts.url + "/" + constructGetUrlPath(request);
                 }
@@ -331,7 +331,7 @@
                         throw "Either 'callback' or ('success' and 'error') callback must be provided " +
                               "when registering a Jolokia job";
                     }
-                    job = $.extend(job,{
+                    job = Jolokia.assignObject(job,{
                         config: callback.config,
                         onlyIfModified: callback.onlyIfModified
                     });
@@ -490,7 +490,7 @@
 
             // Merge a set of parameters with the defaults values
             function mergeInDefaults(params) {
-                return $.extend({}, agentOptions, params);
+                return Jolokia.assignObject({}, agentOptions, params);
             }
 
             // Add a job to the job queue
@@ -696,7 +696,7 @@
                 // Add the proper ifModifiedSince parameter if already called at least once
                 extra = job.onlyIfModified && job.lastModified ? { ifModifiedSince: job.lastModified } : {};
 
-            request.config = $.extend({}, config, request.config, extra);
+            request.config = Jolokia.assignObject({}, config, request.config, extra);
             return request;
         }
 
@@ -990,6 +990,35 @@
         Jolokia.prototype.isError = Jolokia.isError = function(resp) {
             return resp.status == null || resp.status != 200;
         };
+
+        /**
+         * Polyfill method for $.extend and Object.assign.
+         */
+        Jolokia.prototype.assignObject = Jolokia.assignObject = function() {
+            /*
+            if (typeof Object.assign === "function") {
+                return Object.assign.apply(Object, arguments);
+            }
+            */
+            var target = arguments[0]
+            var sources = Array.prototype.slice.call(arguments, 1);
+            if (target === undefined || target === null) {
+                throw new Error("Cannot assign object to undefined or null");
+            }
+
+            sources.forEach(function (source) {
+                if (source === undefined || source === null) {
+                    return;
+                }
+                Object.keys(source).forEach(function (key) {
+                    if (Object.prototype.hasOwnProperty.call(source, key)) {
+                        target[key] = source[key];
+                    }
+                });
+            })
+
+            return target;
+        }
 
         // Return back exported function/constructor
         return Jolokia;

--- a/client/javascript/src/main/javascript/jolokia.test.js
+++ b/client/javascript/src/main/javascript/jolokia.test.js
@@ -127,4 +127,13 @@ describe("jolokia", () => {
         expect(success1).toHaveBeenCalled();
         expect(success2).toHaveBeenCalled();
     });
+
+    test("assignObject", () => {
+        expect(Jolokia.assignObject({}, {a: 1, b: 2, c: 3})).toEqual({a: 1, b: 2, c: 3});
+        expect(Jolokia.assignObject({a: 1, b: 2}, {b: 3, c: 5})).toEqual({a: 1, b: 3, c: 5});
+        expect(Jolokia.assignObject({a: 1}, {a: 2, b: 3}, {b: 4, c: 6})).toEqual({a: 2, b: 4, c: 6});
+        expect(Jolokia.assignObject({a: 1, b: 2, c: 3})).toEqual({a: 1, b: 2, c: 3});
+        expect(() => Jolokia.assignObject(undefined, {})).toThrow();
+        expect(() => Jolokia.assignObject(null, {})).toThrow();
+    });
 });


### PR DESCRIPTION
Now, jolokia-simple.js no more depends on jquery, so it's removed from its module definition.

![image](https://github.com/jolokia/jolokia/assets/156692/307eff58-1d5a-476d-b031-4dbf7af7a7af)

Relates #575
