### PR TITLE
Revert "Set up dependabot to update Maven and NPM dependencies"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This reverts commit eef0ac2b9d8a1c003b3e278ade7b2802ebfb19fc.

It turns out that applying dependabot for the 1.x branch is not a good idea, as 1.x should keep compatible with JDK 6 and thus automatic updates of dependencies have risks of breaking the compatibility.