### PR TITLE
Update dependabot cadence to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/client/javascript"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Weekly seems to be too much considering the current release cadence of Jolokia. More frequent dependency updates just clutter the commit history with the finer updates. Monthly should be fine.

Also fix the directory for npm updates to /client/javascript so that they are correctly updated.