### PR TITLE
Request with HTTPS Origin over HTTP should be rejected for security

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/handler/JolokiaHttpHandler.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/handler/JolokiaHttpHandler.java
@@ -43,6 +43,7 @@ import javax.security.auth.Subject;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpsExchange;
 import org.jolokia.jvmagent.ParsedUri;
 import org.jolokia.server.core.config.ConfigKey;
 import org.jolokia.server.core.http.BackChannelHolder;
@@ -155,7 +156,9 @@ public class JolokiaHttpHandler implements HttpHandler {
 
             // Check access policy
             InetSocketAddress address = pExchange.getRemoteAddress();
-            requestHandler.checkAccess(getHostName(address),
+            String scheme = pExchange instanceof HttpsExchange ? "https" : "http";
+            requestHandler.checkAccess(scheme,
+                                       getHostName(address),
                                        address.getAddress().getHostAddress(),
                                        extractOriginOrReferer(pExchange));
             String method = pExchange.getRequestMethod();

--- a/server/core/src/main/java/org/jolokia/server/core/http/AgentServlet.java
+++ b/server/core/src/main/java/org/jolokia/server/core/http/AgentServlet.java
@@ -317,12 +317,13 @@ public class AgentServlet extends HttpServlet {
     }
 
     @SuppressWarnings({ "PMD.AvoidCatchingThrowable", "PMD.AvoidInstanceofChecksInCatchClause" })
-    private void handle(ServletRequestHandler pReqHandler,HttpServletRequest pReq, HttpServletResponse pResp) throws IOException {
+    private void handle(ServletRequestHandler pReqHandler, HttpServletRequest pReq, HttpServletResponse pResp) throws IOException {
         JSONAware json = null;
 
         try {
             // Check access policy
-            requestHandler.checkAccess(allowDnsReverseLookup ? pReq.getRemoteHost() : null,
+            requestHandler.checkAccess(pReq.getScheme(),
+                                       allowDnsReverseLookup ? pReq.getRemoteHost() : null,
                                        pReq.getRemoteAddr(),
                                        getOriginOrReferer(pReq));
 

--- a/server/core/src/main/java/org/jolokia/server/core/http/HttpRequestHandler.java
+++ b/server/core/src/main/java/org/jolokia/server/core/http/HttpRequestHandler.java
@@ -1,6 +1,8 @@
 package org.jolokia.server.core.http;
 
 import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -271,16 +273,31 @@ public class HttpRequestHandler {
     /**
      * Check whether the given host and/or address is allowed to access this agent.
      *
+     * @param pRequestScheme scheme used to make the request ('http' or 'https')
      * @param pHost host to check
      * @param pAddress address to check
      * @param pOrigin (optional) origin header to check also.
      */
-    public void checkAccess(String pHost, String pAddress, String pOrigin) {
+    public void checkAccess(String pRequestScheme, String pHost, String pAddress, String pOrigin) {
         if (!jolokiaCtx.isRemoteAccessAllowed(pHost != null ? new String[] { pHost, pAddress } : new String[] { pAddress })) {
             throw new SecurityException("No access from client " + pAddress + " allowed");
         }
         if (!jolokiaCtx.isOriginAllowed(pOrigin,true)) {
             throw new SecurityException("Origin " + pOrigin + " is not allowed to call this agent");
+        }
+
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
+        if ("http".equals(pRequestScheme) && pOrigin != null && !"null".equals(pOrigin)) {
+            try {
+                String originScheme = new URL(pOrigin).getProtocol();
+                // Requests with HTTPS origin should not be responded over HTTP,
+                // as it compromises data confidentiality and integrity.
+                if ("https".equals(originScheme)) {
+                    throw new SecurityException("Secure origin " + pOrigin + " should not be processed over HTTP");
+                }
+            } catch (MalformedURLException e) {
+                // Ignore it, should be safe as origin is not https anyway
+            }
         }
     }
 

--- a/server/core/src/test/java/org/jolokia/server/core/http/AgentServletTest.java
+++ b/server/core/src/test/java/org/jolokia/server/core/http/AgentServletTest.java
@@ -539,6 +539,7 @@ public class AgentServletTest {
         servlet.init(config);
         ByteArrayOutputStream sw = initRequestResponseMocks(
                 () -> {
+                    expect(request.getScheme()).andStubReturn("http");
                     expect(request.getHeader("Origin")).andReturn(null);
                     expect(request.getRemoteAddr()).andThrow(new IllegalStateException());
                 },
@@ -710,6 +711,7 @@ public class AgentServletTest {
 
     private Runnable getStandardRequestSetup() {
         return () -> {
+            expect(request.getScheme()).andStubReturn("http");
             expect(request.getHeader("Origin")).andStubReturn(null);
             expect(request.getHeader("Referer")).andStubReturn(null);
             expect(request.getRemoteHost()).andStubReturn("localhost");
@@ -732,6 +734,7 @@ public class AgentServletTest {
 
     private Runnable getDiscoveryRequestSetup(final String url) {
         return () -> {
+            expect(request.getScheme()).andStubReturn("http");
             expect(request.getHeader("Origin")).andStubReturn(null);
             expect(request.getHeader("Referer")).andStubReturn(null);
             expect(request.getRemoteHost()).andReturn("localhost");

--- a/server/core/src/test/java/org/jolokia/server/core/http/HttpRequestHandlerTest.java
+++ b/server/core/src/test/java/org/jolokia/server/core/http/HttpRequestHandlerTest.java
@@ -50,11 +50,22 @@ public class HttpRequestHandlerTest {
     @Test
     public void accessAllowed() throws Exception {
         Restrictor restrictor = createMock(Restrictor.class);
-        expect(restrictor.isRemoteAccessAllowed("localhost","127.0.0.1")).andReturn(true);
+        expect(restrictor.isRemoteAccessAllowed("localhost", "127.0.0.1")).andReturn(true);
         expect(restrictor.isOriginAllowed(isNull(), eq(true))).andReturn(true);
         replay(restrictor);
         init(restrictor);
-        handler.checkAccess("localhost", "127.0.0.1", null);
+        handler.checkAccess("http", "localhost", "127.0.0.1", null);
+        verify(restrictor);
+    }
+
+    @Test
+    public void accessAllowedHttpOriginOverHttps() throws Exception {
+        Restrictor restrictor = createMock(Restrictor.class);
+        expect(restrictor.isRemoteAccessAllowed("localhost", "127.0.0.1")).andReturn(true);
+        expect(restrictor.isOriginAllowed("http://www.jolokia.org", true)).andReturn(true);
+        replay(restrictor);
+        init(restrictor);
+        handler.checkAccess("https", "localhost", "127.0.0.1", "http://www.jolokia.org");
         verify(restrictor);
     }
 
@@ -65,19 +76,30 @@ public class HttpRequestHandlerTest {
         replay(restrictor);
         init(restrictor);
 
-        handler.checkAccess("localhost", "127.0.0.1", null);
+        handler.checkAccess("http", "localhost", "127.0.0.1", null);
         verify(restrictor);
     }
 
     @Test(expectedExceptions = { SecurityException.class })
     public void accessDeniedViaOrigin() throws Exception {
         Restrictor restrictor = createMock(Restrictor.class);
-        expect(restrictor.isRemoteAccessAllowed("localhost","127.0.0.1")).andReturn(true);
-        expect(restrictor.isOriginAllowed("www.jolokia.org",true)).andReturn(false);
+        expect(restrictor.isRemoteAccessAllowed("localhost", "127.0.0.1")).andReturn(true);
+        expect(restrictor.isOriginAllowed("http://www.jolokia.org", true)).andReturn(false);
         replay(restrictor);
         init(restrictor);
 
-        handler.checkAccess("localhost", "127.0.0.1","www.jolokia.org");
+        handler.checkAccess("http", "localhost", "127.0.0.1", "http://www.jolokia.org");
+    }
+
+    @Test(expectedExceptions = { SecurityException.class })
+    public void accessDeniedHttpsOriginOverHttp() throws Exception {
+        Restrictor restrictor = createMock(Restrictor.class);
+        expect(restrictor.isRemoteAccessAllowed("localhost", "127.0.0.1")).andReturn(true);
+        expect(restrictor.isOriginAllowed("https://www.jolokia.org", true)).andReturn(true);
+        replay(restrictor);
+        init(restrictor);
+
+        handler.checkAccess("http", "localhost", "127.0.0.1", "https://www.jolokia.org");
     }
 
 


### PR DESCRIPTION
CORS best practices suggest that if Jolokia receives requests over HTTP that have `Origin: https://...` it should reject them, because Origin=https implies they come from a secure website but receiving the requests over HTTP from there would result in compromising confidentiality and integrity over HTTPS.

I implemented the protection at `HttpRequestHandler#checkAccess()` directly as it is the only location where both the request scheme and origin header value are available. Ideally, `PolicyRestrictor`'s `CorsChecker` should have such checking but the `Restrictor` interface only accepts origin values at this moment, and implementing the checking at `CorsChecker` causes changes and incompatibility to the public interface.

We might want to move the checking logic to `CorsChecker` in the future to make it optional, but for now I think it's fine to have it at `HttpRequestHandler`.