### PR TITLE
Add config option "serializeLong" to support accurate long values in JSON #495

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java
@@ -121,7 +121,7 @@ public class HelpCommand extends AbstractBaseCommand {
 "    --maxDepth <depth>              Maximum number of levels for serialization of beans\n" +
 "    --maxCollectionSize <size>      Maximum number of element in collections to keep when serializing the response\n" +
 "    --maxObjects <nr>               Maximum number of objects to consider for serialization\n" +
-"    --serializeLong <none|string>   How to serialize longs values\n" +
+"    --serializeLong <number|string> How to serialize longs values\n" +
 "    --restrictorClass <class>       Classname of an custom restrictor which must be loadable from the classpath\n" +
 "    --policyLocation <url>          Location of a Jolokia policy file\n" +
 "    --mbeanQualifier <qualifier>    Qualifier to use when registering Jolokia internal MBeans\n" +

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java
@@ -121,6 +121,7 @@ public class HelpCommand extends AbstractBaseCommand {
 "    --maxDepth <depth>              Maximum number of levels for serialization of beans\n" +
 "    --maxCollectionSize <size>      Maximum number of element in collections to keep when serializing the response\n" +
 "    --maxObjects <nr>               Maximum number of objects to consider for serialization\n" +
+"    --serializeLong <none|string>   How to serialize longs values\n" +
 "    --restrictorClass <class>       Classname of an custom restrictor which must be loadable from the classpath\n" +
 "    --policyLocation <url>          Location of a Jolokia policy file\n" +
 "    --mbeanQualifier <qualifier>    Qualifier to use when registering Jolokia internal MBeans\n" +

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/client/util/OptionsAndArgs.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/client/util/OptionsAndArgs.java
@@ -51,7 +51,7 @@ public final class OptionsAndArgs {
             // Jolokia options:
             "historyMaxEntries", "debug!", "debugMaxEntries",
             "logHandlerClass", "logHandlerName", "maxDepth", "maxCollectionSize",
-            "maxObjects", "restrictorClass", "policyLocation", "mbeanQualifier",
+            "maxObjects", "serializeLong", "restrictorClass", "policyLocation", "mbeanQualifier",
             "canonicalNaming", "includeStackTrace", "serializeException",
             "discoveryEnabled", "discoveryAgentUrl", "agentId", "agentDescription",
             // Others:

--- a/client/javascript/src/main/javascript/index.d.ts
+++ b/client/javascript/src/main/javascript/index.d.ts
@@ -43,6 +43,16 @@ export default class Jolokia {
      *     dynamically. If a method is selected which doesn't fit to the request, an error
      *     is raised.
      *   </dd>
+     *   <dt>dataType</dt>
+     *   <dd>
+     *     The type of data specified to the Ajax request. The default value is "json",
+     *     and the response is parsed as JSON to an object. If the value is "text",
+     *     the response is returned as plain text without parsing. The client is then
+     *     responsible for parsing the response. This can be useful when a custom JSON
+     *     parsing is necessary.
+     *     Jolokia Simple API (jolokia-simple.js) doesn't support "text" as dataType.
+     *     This option is available since jolokia.js 2.0.2.
+     *   </dd>
      *   <dt>jsonp</dt>
      *   <dd>
      *     Whether the request should be sent via JSONP (a technique for allowing cross
@@ -413,6 +423,16 @@ export interface BaseRequestOptions extends ProcessParameters {
      */
     method?: "get" | "post";
     /**
+     * The type of data specified to the Ajax request. The default value is "json",
+     * and the response is parsed as JSON to an object. If the value is "text",
+     * the response is returned as plain text without parsing. The client is then
+     * responsible for parsing the response. This can be useful when a custom JSON
+     * parsing is necessary.
+     * Jolokia Simple API (jolokia-simple.js) doesn't support "text" as dataType.
+     * This option is available since jolokia.js 2.0.2.
+     */
+    dataType?: "json" | "text";
+    /**
      * Whether the request should be sent via JSONP (a technique for allowing cross
      * domain request circumventing the infamous "same-origin-policy"). This can be
      * used only with HTTP "get" requests.
@@ -449,7 +469,7 @@ export interface RequestOptions extends BaseRequestOptions {
      * the request is performed synchronously and gives back the response as return
      * value.
      */
-    success?: (response: Response, index: number) => void;
+    success?: (response: Response | string, index: number) => void;
     /**
      * Callback in case a Jolokia error occurs. A Jolokia error is one, in which the HTTP request
      * succeeded with a status code of 200, but the response object contains a status other
@@ -471,7 +491,7 @@ export interface BulkRequestOptions extends BaseRequestOptions {
      * the request is performed synchronously and gives back the response as return
      * value.
      */
-    success?: (response: Response, index: number) => void | ((response: Response, index: number) => void)[];
+    success?: (response: Response | string, index: number) => void | ((response: Response, index: number) => void)[];
     /**
      * Callback in case a Jolokia error occurs. A Jolokia error is one, in which the HTTP request
      * succeeded with a status code of 200, but the response object contains a status other

--- a/client/javascript/src/main/javascript/index.d.ts
+++ b/client/javascript/src/main/javascript/index.d.ts
@@ -338,7 +338,7 @@ export default class Jolokia {
 /**
  * Processing parameters that influence Jolokia operations.
  *
- * @see {@link https://jolokia.org/reference/html/protocol.html#processing-parameters}
+ * @see {@link https://jolokia.org/reference/html/manual/jolokia_protocol.html#processing-parameters}
  */
 export interface ProcessParameters {
     /**
@@ -354,6 +354,16 @@ export interface ProcessParameters {
      * Maximum number of objects contained in the response.
      */
     maxObjects?: number;
+    /**
+     * How to serialize long values in the JSON response: <code>number</code> or <code>string</code>.
+     * The default <code>number</code> simply serializes longs as numbers in JSON.
+     * If set to <code>string</code>, longs are serialized as strings.
+     * It can be useful when a JavaScript client consumes the JSON response,
+     * because numbers greater than the max safe integer don't retain their precision
+     * in JavaScript.
+     * **Added since Jolokia 2.0.3**
+     */
+    serializeLong?: "number" | "string";
     /**
      * If set to true, errors during JMX operations and JSON serialization
      * are ignored.Otherwise if a single deserialization fails, the whole request
@@ -404,7 +414,7 @@ export interface ProcessParameters {
 /**
  * Base request options that influence a Jolokia request.
  *
- * @see {@link https://jolokia.org/reference/html/clients.html#js-request-options}
+ * @see {@link https://jolokia.org/reference/html/manual/clients.html#js-request-options}
  */
 export interface BaseRequestOptions extends ProcessParameters {
     /**

--- a/client/javascript/src/main/javascript/jolokia.js
+++ b/client/javascript/src/main/javascript/jolokia.js
@@ -66,7 +66,8 @@
 
         // Processing parameters which are added to the
         // URL as query parameters if given as options
-        var PROCESSING_PARAMS = ["maxDepth", "maxCollectionSize", "maxObjects", "ignoreErrors", "canonicalNaming",
+        var PROCESSING_PARAMS = ["maxDepth", "maxCollectionSize", "maxObjects", "serializeLong",
+                                 "ignoreErrors", "canonicalNaming",
                                  "serializeException", "includeStackTrace", "ifModifiedSince"];
 
         /**

--- a/client/javascript/src/main/javascript/jolokia.test.js
+++ b/client/javascript/src/main/javascript/jolokia.test.js
@@ -42,6 +42,27 @@ describe("jolokia", () => {
         expect(response.value).toBeNull();
     });
 
+    test("basic request with dataType=text", () => {
+        $.ajax = jest.fn(() => ({
+            status: 200,
+            responseText: `{
+                "request": {"type": "read", "mbean": "java.lang:type=Memory", "attribute": "HeapMemoryUsage", "path": "used"},
+                "status": 200,
+                "value": 900719925474099123,
+                "timestamp": 1694682372
+            }`
+        }));
+
+        const request = {type: "read", mbean: "java.lang:type=Memory", attribute: "HeapMemoryUsage", path: "used"};
+        const jolokia = new Jolokia("/jolokia");
+        const response1 = jolokia.request(request);
+        expect(response1.status).toEqual(200);
+        expect(String(response1.value)).not.toEqual("900719925474099123");
+        const response2 = jolokia.request(request, {dataType: 'text'});
+        expect(typeof response2).toBe("string");
+        expect(response2).toContain("900719925474099123");
+    });
+
     test("bulk request (sync)", () => {
         $.ajax = jest.fn(() => ({
             status: 200,

--- a/server/core/src/main/java/org/jolokia/server/core/backend/BackendManager.java
+++ b/server/core/src/main/java/org/jolokia/server/core/backend/BackendManager.java
@@ -184,6 +184,7 @@ public class BackendManager {
                     maxDepth(pJmxReq.getParameterAsInt(ConfigKey.MAX_DEPTH)).
                     maxCollectionSize(pJmxReq.getParameterAsInt(ConfigKey.MAX_COLLECTION_SIZE)).
                     maxObjects(pJmxReq.getParameterAsInt(ConfigKey.MAX_OBJECTS)).
+                    serializeLong(pJmxReq.getParameter(ConfigKey.SERIALIZE_LONG)).
                     faultHandler(pJmxReq.getValueFaultHandler()).
                                             useAttributeFilter(pJmxReq.getPathParts() != null).
                     build();

--- a/server/core/src/main/java/org/jolokia/server/core/config/ConfigKey.java
+++ b/server/core/src/main/java/org/jolokia/server/core/config/ConfigKey.java
@@ -80,6 +80,11 @@ public enum ConfigKey {
     MAX_OBJECTS("maxObjects",true, true),
 
     /**
+     * How to serialize long values: "none" or "string"
+     */
+    SERIALIZE_LONG("serializeLong", true, true),
+
+    /**
      * Custom restrictor to be used instead of default one
      */
     RESTRICTOR_CLASS("restrictorClass", true, false),

--- a/server/core/src/main/java/org/jolokia/server/core/config/ConfigKey.java
+++ b/server/core/src/main/java/org/jolokia/server/core/config/ConfigKey.java
@@ -80,7 +80,7 @@ public enum ConfigKey {
     MAX_OBJECTS("maxObjects",true, true),
 
     /**
-     * How to serialize long values: "none" or "string"
+     * How to serialize long values: "number" or "string"
      */
     SERIALIZE_LONG("serializeLong", true, true),
 

--- a/server/core/src/main/java/org/jolokia/server/core/service/serializer/SerializeOptions.java
+++ b/server/core/src/main/java/org/jolokia/server/core/service/serializer/SerializeOptions.java
@@ -47,17 +47,21 @@ public final class SerializeOptions {
     // Maximum number of objects to return
     private final int maxObjects;
 
+    // How to serialize long values: "none" or "string"
+    private final String serializeLong;
+
     // Handler which determines what should be done when
     // extracting of a value fails
     private final ValueFaultHandler faultHandler;
 
     // Use a builder to construct this object
-    private SerializeOptions(int pMaxDepth, int pMaxCollectionSize, int pMaxObjects,
+    private SerializeOptions(int pMaxDepth, int pMaxCollectionSize, int pMaxObjects, String pSerializeLong,
                              ValueFaultHandler pFaultHandler) {
         maxDepth = pMaxDepth;
         maxCollectionSize = pMaxCollectionSize;
         maxObjects = pMaxObjects;
         faultHandler = pFaultHandler;
+        serializeLong = pSerializeLong;
     }
 
     /**
@@ -92,6 +96,15 @@ public final class SerializeOptions {
     }
 
     /**
+     * Get the option for serializing long values.
+     *
+     * @return the option for serializing long values
+     */
+    public String getSerializeLong() {
+        return serializeLong;
+    }
+
+    /**
      * Get the configure fault handler which determines, how extractions fault are dealt with
      *
      * @return the configured fault handler
@@ -114,6 +127,8 @@ public final class SerializeOptions {
         private int maxDepth;
         private int maxCollectionSize;
         private int maxObjects;
+
+        private String serializeLong;
 
         private ValueFaultHandler faultHandler;
         private boolean useAttributeFilter;
@@ -138,6 +153,7 @@ public final class SerializeOptions {
             hardMaxDepth = pHardMaxDepth;
             hardMaxCollectionSize = pHardMaxCollectionSize;
             hardMaxObjects = pHardMaxObjects;
+            serializeLong = "none";
             faultHandler = ValueFaultHandler.THROWING_VALUE_FAULT_HANDLER;
         }
 
@@ -178,6 +194,17 @@ public final class SerializeOptions {
         }
 
         /**
+         * Set how to serialize long values. Can be either "none" or "string".
+         *
+         * @param pSerializeLong how to serialize long values
+         * @return this builder
+         */
+        public Builder serializeLong(String pSerializeLong) {
+            serializeLong = pSerializeLong;
+            return this;
+        }
+
+        /**
          * Set the handler which determines what should be done when
          * extracting of a value fails.
          *
@@ -204,6 +231,7 @@ public final class SerializeOptions {
             useAttributeFilter = pUseFilter;
             return this;
         }
+
         /**
          * Build the convert options and reset this builder
          *
@@ -213,10 +241,11 @@ public final class SerializeOptions {
             ValueFaultHandler handler = useAttributeFilter ?
                     new PathAttributeFilterValueFaultHandler(faultHandler) :
                     faultHandler;
-            SerializeOptions opts = new SerializeOptions(maxDepth,maxCollectionSize,maxObjects,handler);
+            SerializeOptions opts = new SerializeOptions(maxDepth,maxCollectionSize,maxObjects,serializeLong,handler);
             maxDepth = 0;
             maxCollectionSize = 0;
             maxObjects = 0;
+            serializeLong = "none";
             return opts;
         }
 

--- a/server/core/src/main/java/org/jolokia/server/core/service/serializer/SerializeOptions.java
+++ b/server/core/src/main/java/org/jolokia/server/core/service/serializer/SerializeOptions.java
@@ -47,7 +47,7 @@ public final class SerializeOptions {
     // Maximum number of objects to return
     private final int maxObjects;
 
-    // How to serialize long values: "none" or "string"
+    // How to serialize long values: "number" or "string"
     private final String serializeLong;
 
     // Handler which determines what should be done when
@@ -153,7 +153,7 @@ public final class SerializeOptions {
             hardMaxDepth = pHardMaxDepth;
             hardMaxCollectionSize = pHardMaxCollectionSize;
             hardMaxObjects = pHardMaxObjects;
-            serializeLong = "none";
+            serializeLong = "number";
             faultHandler = ValueFaultHandler.THROWING_VALUE_FAULT_HANDLER;
         }
 
@@ -194,7 +194,7 @@ public final class SerializeOptions {
         }
 
         /**
-         * Set how to serialize long values. Can be either "none" or "string".
+         * Set how to serialize long values. Can be either "number" or "string".
          *
          * @param pSerializeLong how to serialize long values
          * @return this builder
@@ -245,7 +245,7 @@ public final class SerializeOptions {
             maxDepth = 0;
             maxCollectionSize = 0;
             maxObjects = 0;
-            serializeLong = "none";
+            serializeLong = "number";
             return opts;
         }
 

--- a/service/serializer/src/main/java/org/jolokia/service/serializer/json/BeanExtractor.java
+++ b/service/serializer/src/main/java/org/jolokia/service/serializer/json/BeanExtractor.java
@@ -148,9 +148,16 @@ public class BeanExtractor implements Extractor {
 
     private Object exctractJsonifiedValue(ObjectToJsonConverter pConverter, Object pValue, Stack<String> pPathParts)
             throws AttributeNotFoundException {
-        if (pValue.getClass().isPrimitive() || FINAL_CLASSES.contains(pValue.getClass()) || pValue instanceof JSONAware) {
+        Class<?> pClazz = pValue.getClass();
+        if (pClazz.isPrimitive() || FINAL_CLASSES.contains(pClazz) || pValue instanceof JSONAware) {
             // No further diving, use these directly
-            return pValue;
+            if (pClazz.equals(Long.class) && "string".equals(pConverter.getSerializeLong())) {
+                // Long value can exceed max safe integer in JS, so convert it to
+                // a string when the option is specified
+                return pValue.toString();
+            } else {
+                return pValue;
+            }
         } else {
             // For the rest we build up a JSON map with the attributes as keys and the value are
             List<String> attributes = extractBeanAttributes(pValue);

--- a/service/serializer/src/main/java/org/jolokia/service/serializer/json/ObjectSerializationContext.java
+++ b/service/serializer/src/main/java/org/jolokia/service/serializer/json/ObjectSerializationContext.java
@@ -96,6 +96,15 @@ class ObjectSerializationContext {
     }
 
     /**
+     * Get the option for serializing long values.
+     *
+     * @return the option for serializing long values
+     */
+    public String getSerializeLong() {
+        return options.getSerializeLong();
+    }
+
+    /**
      * The fault handler used for errors during serialization
      *
      * @return the value fault handler

--- a/service/serializer/src/main/java/org/jolokia/service/serializer/json/ObjectToJsonConverter.java
+++ b/service/serializer/src/main/java/org/jolokia/service/serializer/json/ObjectToJsonConverter.java
@@ -256,6 +256,16 @@ public final class ObjectToJsonConverter {
     }
 
     /**
+     * Get the option for serializing long values.
+     *
+     * @return the option for serializing long values
+     */
+    String getSerializeLong() {
+        ObjectSerializationContext ctx = stackContextLocal.get();
+        return ctx.getSerializeLong();
+    }
+
+    /**
      * Get the fault handler used for dealing with exceptions during value extraction.
      *
      * @return the fault handler

--- a/service/serializer/src/test/java/org/jolokia/service/serializer/json/ObjectToJsonConverterTest.java
+++ b/service/serializer/src/test/java/org/jolokia/service/serializer/json/ObjectToJsonConverterTest.java
@@ -186,6 +186,16 @@ public class ObjectToJsonConverterTest {
         }
     }
 
+    @Test
+    public void convertLong() throws AttributeNotFoundException {
+        long value = 900719925474099123L;
+        Object ret1 = converter.serialize(value, null, SerializeOptions.DEFAULT);
+        assertEquals(900719925474099123L, ret1);
+        SerializeOptions.Builder builder = new SerializeOptions.Builder();
+        Object ret2 = converter.serialize(value, null, builder.serializeLong("string").build());
+        assertEquals("900719925474099123", ret2);
+    }
+
     // ============================================================================
     // TestBeans:
 

--- a/src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc
@@ -347,14 +347,14 @@ no limit is imposed.
 |Default: `0`
 
 |`serializeLong`
-|How to serialize long values in the JSON response: `none` or `string`.
-The default `none` simply serializes longs as numbers in JSON.
+|How to serialize long values in the JSON response: `number` or `string`.
+The default `number` simply serializes longs as numbers in JSON.
 If set to `string`, longs are serialized as strings.
 It can be useful when a JavaScript client consumes the JSON response,
 because numbers greater than the max safe integer don't retain their precision
 in JavaScript. +
 *Added since Jolokia 2.0.3*
-|Default: `none`
+|Default: `number`
 
 |`policyLocation`
 |Path to the XML policy file

--- a/src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc
@@ -327,6 +327,35 @@ Multiple cipher suites can be configured by using additional options with consec
 suffixes like in `sslCipherSuite.1`, `sslCipherSuite.2`, ...
 |
 
+|`maxDepth`
+|Maximum depth when traversing bean properties.
+If set to 0, depth checking is disabled
+|Default: `15`
+
+|`maxCollectionSize`
+|Maximum size of collections returned when
+serializing to JSON. When set to 0,
+collections are never truncated.
+|Default: `0`
+
+|`maxObjects`
+|Maximum number of objects which are traversed
+when serializing a single response. Use this
+as an airbag to avoid boosting your memory and
+network traffic. Nevertheless, when set to 0
+no limit is imposed.
+|Default: `0`
+
+|`serializeLong`
+|How to serialize long values in the JSON response: `none` or `string`.
+The default `none` simply serializes longs as numbers in JSON.
+If set to `string`, longs are serialized as strings.
+It can be useful when a JavaScript client consumes the JSON response,
+because numbers greater than the max safe integer don't retain their precision
+in JavaScript. +
+*Added since Jolokia 2.0.3*
+|Default: `none`
+
 |`policyLocation`
 |Path to the XML policy file
 |

--- a/src/documentation/manual/modules/ROOT/pages/agents/osgi.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/osgi.adoc
@@ -194,9 +194,9 @@ network traffic. Nevertheless, when set to 0
 no limit is imposed.
 
 |`org.jolokia.serializeLong`
-|`none`
-|How to serialize long values in the JSON response: `none` or `string`.
-The default `none` simply serializes longs as numbers in JSON.
+|`number`
+|How to serialize long values in the JSON response: `number` or `string`.
+The default `number` simply serializes longs as numbers in JSON.
 If set to `string`, longs are serialized as strings.
 It can be useful when a JavaScript client consumes the JSON response,
 because numbers greater than the max safe integer don't retain their precision

--- a/src/documentation/manual/modules/ROOT/pages/agents/osgi.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/osgi.adoc
@@ -193,6 +193,16 @@ as an airbag to avoid boosting your memory and
 network traffic. Nevertheless, when set to 0
 no limit is imposed.
 
+|`org.jolokia.serializeLong`
+|`none`
+|How to serialize long values in the JSON response: `none` or `string`.
+The default `none` simply serializes longs as numbers in JSON.
+If set to `string`, longs are serialized as strings.
+It can be useful when a JavaScript client consumes the JSON response,
+because numbers greater than the max safe integer don't retain their precision
+in JavaScript. +
+*Added since Jolokia 2.0.3*
+
 |`org.jolokia.historyMaxEntries`
 |`10`
 |Number of entries to keep in the history. This can be changed at

--- a/src/documentation/manual/modules/ROOT/pages/agents/war.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/war.adoc
@@ -159,6 +159,16 @@ network traffic. Nevertheless, when set to 0
 no limit is imposed.
 |Default: `0`
 
+|`serializeLong`
+|How to serialize long values in the JSON response: `none` or `string`.
+The default `none` simply serializes longs as numbers in JSON.
+If set to `string`, longs are serialized as strings.
+It can be useful when a JavaScript client consumes the JSON response,
+because numbers greater than the max safe integer don't retain their precision
+in JavaScript. +
+*Added since Jolokia 2.0.3*
+|Default: `none`
+
 |`mbeanQualifier`
 |Qualifier to add to the ObjectName of Jolokia's own
 MBeans. This can become necessary if more than one agent is

--- a/src/documentation/manual/modules/ROOT/pages/agents/war.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/war.adoc
@@ -160,14 +160,14 @@ no limit is imposed.
 |Default: `0`
 
 |`serializeLong`
-|How to serialize long values in the JSON response: `none` or `string`.
-The default `none` simply serializes longs as numbers in JSON.
+|How to serialize long values in the JSON response: `number` or `string`.
+The default `number` simply serializes longs as numbers in JSON.
 If set to `string`, longs are serialized as strings.
 It can be useful when a JavaScript client consumes the JSON response,
 because numbers greater than the max safe integer don't retain their precision
 in JavaScript. +
 *Added since Jolokia 2.0.3*
-|Default: `none`
+|Default: `number`
 
 |`mbeanQualifier`
 |Qualifier to add to the ObjectName of Jolokia's own

--- a/src/documentation/manual/modules/ROOT/pages/client/javascript.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/client/javascript.adoc
@@ -169,6 +169,15 @@ requests. If not given, a HTTP method is determined
 dynamically. If a method is selected which doesn't fit to the
 request, an error is raised.
 
+|`dataType`
+|The type of data specified to the Ajax request. The default value is `json`,
+and the response is parsed as JSON to an object. If the value is `text`,
+the response is returned as plain text without parsing. The client is then
+responsible for parsing the response. This can be useful when a custom JSON
+parsing is necessary. +
+Jolokia Simple API (jolokia-simple.js) doesn't support `text` as dataType. +
+*Added since jolokia.js 2.0.2*
+
 |`jsonp`
 |Whether the request should be sent via JSONP (a technique
 for allowing cross domain request circumventing the infamous
@@ -200,7 +209,7 @@ console by default.
 |Global error callback called when the Ajax request itself
 failed. It obtains the same arguments as the error callback
 given for `jQuery.ajax()`, i.e. the
-`XmlHttpResonse`, a text status and an
+`XmlHttpResponse`, a text status and an
 error thrown. Refer to the jQuery documentation for more
 information about this error handler.
 
@@ -223,6 +232,15 @@ If larger, the collection is returned truncated.
 |`maxObjects`
 |Maximum number of objects contained in the response.
 
+|`serializeLong`
+|How to serialize long values in the JSON response: `none` or `string`.
+The default `none` simply serializes longs as numbers in JSON.
+If set to `string`, longs are serialized as strings.
+It can be useful when a JavaScript client consumes the JSON response,
+because numbers greater than the max safe integer don't retain their precision
+in JavaScript. +
+*Added since Jolokia 2.0.3*
+
 |`ignoreErrors`
 |If set to "true", errors during JMX operations and JSON
 serialization are ignored. Otherwise if a single
@@ -240,7 +258,7 @@ in the response object.
 
 |`includeStackTrace`
 |By default, a stacktrace is returned with every error (key: `stacktrace`)
-This can be ommitted by setting the value of this option to false.
+This can be omitted by setting the value of this option to false.
 
 |`ifModifiedSince`
 |The `LIST` operations provides an

--- a/src/documentation/manual/modules/ROOT/pages/client/javascript.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/client/javascript.adoc
@@ -233,8 +233,8 @@ If larger, the collection is returned truncated.
 |Maximum number of objects contained in the response.
 
 |`serializeLong`
-|How to serialize long values in the JSON response: `none` or `string`.
-The default `none` simply serializes longs as numbers in JSON.
+|How to serialize long values in the JSON response: `number` or `string`.
+The default `number` simply serializes longs as numbers in JSON.
 If set to `string`, longs are serialized as strings.
 It can be useful when a JavaScript client consumes the JSON response,
 because numbers greater than the max safe integer don't retain their precision

--- a/src/documentation/manual/modules/ROOT/pages/jolokia_protocol.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/jolokia_protocol.adoc
@@ -538,6 +538,14 @@ and cannot be exceeded by a query parameter.
 `maxObjects`:: Number of objects to visit in total. A hard limit
 can be configured in the agent's configuration.
 
+`serializeLong`:: How to serialize long values in the JSON response: `number` or `string`.
+The default `number` simply serializes longs as numbers in JSON.
+If set to `string`, longs are serialized as strings.
+It can be useful when a JavaScript client consumes the JSON response,
+because numbers greater than the max safe integer don't retain their precision
+in JavaScript.
+*Added since Jolokia 2.0.3*
+
 `ignoreErrors`:: If set to `true`, a Jolokia operation will not return an
 error if an JMX operation fails, but includes the
 exception message as value. This is useful for e.g. the


### PR DESCRIPTION
Fix #495

This pull req is still a draft but let me share this early so that it could be checked by the experts.

Here are the highlights:

- I proposed `serializeLong` option with three values `none`, `string` and `bigint` at #495, but since the current json library json-simple doesn't support bigint notation in JSON (#686) I dropped `bigint` from this implementation. Now it only supports `none` and `string`.
- We may consider supporting `bigint` option in the future but we would also need to be aware that the bigint notation doesn't comply with [the standard JSON specification](https://www.json.org/json-en.html) and JSON is now effectively an universal message format that's not monopolized by JavaScript.

I'm working to add a few more commits to it:
- [x] Add client side option for `jolokia.js` that allows users to make the client return a string response instead of the `JSON.parse`'d object to provide yet another solution to the problem at the client side
- [x] Update docs with the newly added options