### PR TITLE
A Flaky Test Fixed

### DIFF
--- a/support/spring/src/test/java/org/jolokia/support/spring/BaseServerTest.java
+++ b/support/spring/src/test/java/org/jolokia/support/spring/BaseServerTest.java
@@ -35,7 +35,7 @@ class BaseServerTest {
             URL url = new URL(server.getUrl());
             System.out.println(">>> URL to check: " + server.getUrl());
             String resp = EnvTestUtil.readToString(url.openStream());
-            assertTrue(resp.matches(".*type.*version.*" + Version.getAgentVersion() + ".*"));
+            assertTrue(resp.matches(".*type.*version.*") && resp.matches(".*" + Version.getAgentVersion() + ".*"));
         } finally {
             server.destroy();
             try {


### PR DESCRIPTION
**Issue**:
There is a "flaky test" ([definition](https://www.browserstack.com/test-observability/features/test-reporting/what-is-flaky-test#:~:text=A%20flaky%20test%20refers%20to,challenges%20for%20software%20development%20teams)) found 

`String resp = EnvTestUtil.readToString(url.openStream());`
The string value of `resp` parsed from the stream may have an inconsistent order, which could result in occassional failure in unit tests.


**Observation**:
`assertTrue(resp.matches(".*type.*version.*" + Version.getAgentVersion() + ".*"));`
Our assumption in this test case was that the version number would be written after a type version. However, this order is not guaranteed.

Case 1: (Fail)
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/38a2aea5-8970-44c8-b0f3-f0e07802b95c">

Case 2: (Fail)
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/d501f89a-41fc-4c1c-8b3e-497116c45d45">

Case 3: (Success)
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/27f158d2-ae5e-47a7-8123-73efeb6310a7">

**Improvement**
Change the test case into:
`assertTrue(resp.matches(".*type.*version.*") && resp.matches(".*" + Version.getAgentVersion() + ".*"));`
where we ignore the order 