### PR TITLE
flaky test fixed

### DIFF
--- a/agent/jvm/src/test/java/org/jolokia/jvmagent/JolokiaServerTest.java
+++ b/agent/jvm/src/test/java/org/jolokia/jvmagent/JolokiaServerTest.java
@@ -338,8 +338,7 @@ public class JolokiaServerTest {
 
                     URL url = new URL(server.getUrl());
                     String resp = EnvTestUtil.readToString(url.openStream());
-                    assertTrue(
-                        resp.matches(".*type.*version.*" + Version.getAgentVersion() + ".*"));
+                    assertTrue(resp.matches(".*type.*version.*") && resp.matches(".*" + Version.getAgentVersion() + ".*"));
                     if (!protocols.contains(protocol) || !cipherSuites.contains(cipherSuite)) {
                         fail(String.format("Expected SSLHandshakeException with the %s protocol and %s cipher suite", protocol, cipherSuite));
                     }


### PR DESCRIPTION
Hi, there's another flaky test detected by our Nondex tool. It is basically the same assert statement caused the flakiness on the [previous PR](https://github.com/jolokia/jolokia/pull/750)