### PR TITLE
789: Deeper testing, and found a few fields that should be integer

### DIFF
--- a/client/jmx-adapter/src/main/java/org/jolokia/client/jmxadapter/ToOpenTypeConverter.java
+++ b/client/jmx-adapter/src/main/java/org/jolokia/client/jmxadapter/ToOpenTypeConverter.java
@@ -373,6 +373,7 @@ public class ToOpenTypeConverter {
         //may be null on Java 10
         cacheType(STRING, "jdk.management.jfr:type=FlightRecorder.EventTypes.item.description");
         cacheType(STRING, "jdk.management.jfr:type=FlightRecorder.getRecordingOptions.destination");
+        cacheType(INTEGER, "java.lang:name=G1 Old Generation,type=GarbageCollector.LastGcInfo.GcThreadCount", "java.lang:name=G1 Concurrent GC,type=GarbageCollector.LastGcInfo.GcThreadCount", "java.lang:name=G1 Young Generation,type=GarbageCollector.LastGcInfo.GcThreadCount");
         return TYPE_SPECIFICATIONS.get(name);
     }
 


### PR DESCRIPTION
Changing to default to `java.lang.Long` largely fixed binary compatibility issues between local/RMI connections and jolokia. 
I added some tests do do deeper type testing (We should be aware about complexity , brittleness (if any) and maintainability of these tests ...) .

It actually uncovered 3 cases that should be integer instead of long.

cc: @grgrzybek 