### PR TITLE
[832] Support Attribute Value Interception and Masking for Security Use Cases

### DIFF
--- a/server/core/src/main/java/org/jolokia/server/core/service/api/Restrictor.java
+++ b/server/core/src/main/java/org/jolokia/server/core/service/api/Restrictor.java
@@ -113,4 +113,16 @@ public interface Restrictor {
     default boolean ignoreScheme() {
         return false;
     }
+
+    /**
+     * Providing a way to verify/secure the attribute value before its exposed
+     *
+     * @param pName mbean object name
+     * @param pAttribute attribute name
+     * @param object attribute value
+     * @return restricted attribute value
+     */
+    default Object restrictedAttributeValue(ObjectName pName, String pAttribute, Object object) {
+        return object;
+    }
 }

--- a/server/core/src/main/java/org/jolokia/server/core/service/impl/JolokiaContextImpl.java
+++ b/server/core/src/main/java/org/jolokia/server/core/service/impl/JolokiaContextImpl.java
@@ -171,6 +171,11 @@ public class JolokiaContextImpl implements JolokiaContext {
     }
 
     /** {@inheritDoc} */
+    public Object restrictedAttributeValue(ObjectName pName, String pAttribute, Object object) {
+        return getRestrictor().restrictedAttributeValue(pName, pAttribute, object);
+    }
+
+    /** {@inheritDoc} */
     private Configuration getConfiguration() {
         return serviceManager.getConfiguration();
     }

--- a/server/core/src/test/java/org/jolokia/server/core/osgi/security/DelegatingRestrictorTest.java
+++ b/server/core/src/test/java/org/jolokia/server/core/osgi/security/DelegatingRestrictorTest.java
@@ -86,6 +86,8 @@ public class DelegatingRestrictorTest {
         assertFalse(restrictor.isRemoteAccessAllowed("localhost", "127.0.0.1"));
         assertTrue(restrictor.isOriginAllowed("http://bla.com", false));
         assertFalse(restrictor.isObjectNameHidden(new ObjectName("java.lang:type=Memory")));
+        assertEquals(restrictor.restrictedAttributeValue(new ObjectName("java.lang:type=Memory"),
+            "HeapMemoryUsage", "70%"), "*****");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,expectedExceptionsMessageRegExp = ".*Impossible.*")
@@ -141,6 +143,13 @@ public class DelegatingRestrictorTest {
 
         public boolean isObjectNameHidden(ObjectName name) {
             return isHidden;
+        }
+
+        public Object restrictedAttributeValue(ObjectName pName, String pAttribute, Object object) {
+            if("HeapMemoryUsage".equals(pAttribute)) {
+                return "*****";
+            }
+            return object;
         }
     }
 }


### PR DESCRIPTION
As a developer, I would like to intercept every attribute value during read operations (and optionally write operations), in order to mask sensitive values or post-process them for security or auditing reasons.

related issue : https://github.com/jolokia/jolokia/issues/832


Signed-off-by:Radha Krishnan <radhakrishnan10192@gmail.com>