### PR TITLE
Remove deprecated Pragma header

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/handler/JolokiaHttpHandler.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/handler/JolokiaHttpHandler.java
@@ -273,7 +273,6 @@ public class JolokiaHttpHandler implements HttpHandler {
 
         // Avoid caching at all costs
         headers.set("Cache-Control", "no-cache");
-        headers.set("Pragma","no-cache");
 
         // Check for a date header and set it accordingly to the recommendations of
         // RFC-2616. See also {@link AgentServlet#setNoCacheHeaders()}

--- a/agent/jvm/src/test/java/org/jolokia/jvmagent/handler/JolokiaHttpHandlerTest.java
+++ b/agent/jvm/src/test/java/org/jolokia/jvmagent/handler/JolokiaHttpHandlerTest.java
@@ -190,7 +190,6 @@ public class JolokiaHttpHandlerTest {
         assertTrue(result.contains("\"used\""));
 
         assertEquals(header.getFirst("Cache-Control"),"no-cache");
-        assertEquals(header.getFirst("Pragma"),"no-cache");
         SimpleDateFormat rfc1123Format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
         rfc1123Format.setTimeZone(TimeZone.getTimeZone("GMT"));
 

--- a/server/core/src/main/java/org/jolokia/server/core/http/AgentServlet.java
+++ b/server/core/src/main/java/org/jolokia/server/core/http/AgentServlet.java
@@ -578,7 +578,6 @@ public class AgentServlet extends HttpServlet {
 
     private void setNoCacheHeaders(HttpServletResponse pResp) {
         pResp.setHeader("Cache-Control", "no-cache");
-        pResp.setHeader("Pragma","no-cache");
         // Check for a date header and set it accordingly to the recommendations of
         // RFC-2616 (http://tools.ietf.org/html/rfc2616#section-14.21)
         //

--- a/server/core/src/test/java/org/jolokia/server/core/http/AgentServletTest.java
+++ b/server/core/src/test/java/org/jolokia/server/core/http/AgentServletTest.java
@@ -502,7 +502,6 @@ public class AgentServletTest {
 
     private void setNoCacheHeaders(HttpServletResponse pResp) {
         pResp.setHeader("Cache-Control", "no-cache");
-        pResp.setHeader("Pragma","no-cache");
         pResp.setDateHeader(eq("Date"),anyLong());
         pResp.setDateHeader(eq("Expires"),anyLong());
     }


### PR DESCRIPTION
Pragma header is deprecated - Cache-Control is enough.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Pragma

Let me know if any other changes are needed.