### PR TITLE
Make maxEntries configurable for pull notification store

### DIFF
--- a/server/core/src/main/java/org/jolokia/server/core/config/ConfigKey.java
+++ b/server/core/src/main/java/org/jolokia/server/core/config/ConfigKey.java
@@ -40,6 +40,11 @@ public enum ConfigKey {
     HISTORY_MAX_ENTRIES("historyMaxEntries",true, false, "10"),
 
     /**
+     * Maximum number of entries to keep per notification subscription in the pull notification store
+     */
+    NOTIFICATION_MAX_ENTRIES("notificationMaxEntries", true, false, "100"),
+
+    /**
      * Whether debug is switched on or not
      */
     DEBUG("debug",true, false, Constants.FALSE),

--- a/service/notif/pull/src/main/java/org/jolokia/service/notif/pull/PullNotificationBackend.java
+++ b/service/notif/pull/src/main/java/org/jolokia/service/notif/pull/PullNotificationBackend.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import javax.management.Notification;
 import javax.management.ObjectName;
 
+import org.jolokia.server.core.config.ConfigKey;
 import org.jolokia.server.core.http.BackChannel;
 import org.jolokia.server.core.service.api.AbstractJolokiaService;
 import org.jolokia.server.core.service.api.JolokiaContext;
@@ -25,7 +26,7 @@ public class PullNotificationBackend extends AbstractJolokiaService<Notification
     private PullNotificationStore store;
 
     // maximal number of entries *per* notification subscription
-    private final int maxEntries = 100;
+    private int maxEntries;
 
     // name as the MBean has been registered
     private ObjectName objectName;
@@ -44,9 +45,17 @@ public class PullNotificationBackend extends AbstractJolokiaService<Notification
     public synchronized void init(JolokiaContext pContext) {
         if (getJolokiaContext() == null) {
             super.init(pContext);
-            // TODO: Get configuration parameter for maxEntries
+            maxEntries = getMaxEntries(pContext);
             store = new PullNotificationStore(maxEntries);
-            objectName = registerJolokiaMBean(OBJECT_NAME,store);
+            objectName = registerJolokiaMBean(OBJECT_NAME, store);
+        }
+    }
+
+    private int getMaxEntries(JolokiaContext pCtx) {
+        try {
+            return Integer.parseInt(pCtx.getConfig(ConfigKey.NOTIFICATION_MAX_ENTRIES));
+        } catch (NumberFormatException exp) {
+            return Integer.parseInt(ConfigKey.NOTIFICATION_MAX_ENTRIES.getDefaultValue());
         }
     }
 

--- a/service/notif/pull/src/test/java/org/jolokia/service/notif/pull/PullNotificationBackendTest.java
+++ b/service/notif/pull/src/test/java/org/jolokia/service/notif/pull/PullNotificationBackendTest.java
@@ -60,7 +60,24 @@ public class PullNotificationBackendTest {
     public void testConfig() {
         JSONObject cfg = (JSONObject) backend.getConfig();
         Assert.assertEquals(cfg.get("store"), "jolokia:type=NotificationStore,agent=test");
-        Assert.assertTrue(cfg.containsKey("maxEntries"));
+        Assert.assertEquals(cfg.get("maxEntries"), 100);
+    }
+
+    @Test
+    public void testCustomMaxEntries() throws Exception {
+        TestJolokiaContext customContext = new TestJolokiaContext.Builder()
+                .config(ConfigKey.AGENT_ID, "test-custom",
+                        ConfigKey.NOTIFICATION_MAX_ENTRIES, "50")
+                .build();
+        PullNotificationBackend customBackend = new PullNotificationBackend(0);
+        try {
+            customBackend.init(customContext);
+            JSONObject cfg = (JSONObject) customBackend.getConfig();
+            Assert.assertEquals(cfg.get("maxEntries"), 50);
+        } finally {
+            customBackend.destroy();
+            customContext.destroy();
+        }
     }
 
    @Test

--- a/src/documentation/manual/modules/ROOT/pages/agents/osgi.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/osgi.adoc
@@ -231,6 +231,11 @@ Additionally we can use:
 |Number of entries to keep in the history. This can be changed at
 runtime via the Jolokia config MBean.
 
+|`org.jolokia.notificationMaxEntries`
+|`100`
+|Maximum number of entries to keep per notification
+subscription in the pull notification store.
+
 |`org.jolokia.registerWhiteboardServlet`
 |`true`
 |If `true` the bundle registers `org.jolokia.server.core.osgi.OsgiAgentServlet` OSGi service. If `false`, it's your

--- a/src/documentation/manual/modules/ROOT/pages/agents/war.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/war.adoc
@@ -130,6 +130,11 @@ a|Default: `org.jolokia`
 runtime via the config MBean.
 |Default: `10`
 
+|`notificationMaxEntries`
+|Maximum number of entries to keep per notification
+subscription in the pull notification store.
+|Default: `100`
+
 |`debugMaxEntries`
 |Maximum number of entries to keep in the local
 debug history (if enabled). Can be changed via


### PR DESCRIPTION
## Summary

- Add `ConfigKey.NOTIFICATION_MAX_ENTRIES` (`notificationMaxEntries`) with default `100`
- Read from `JolokiaContext` config in `PullNotificationBackend.init()`, replacing the hardcoded value
- Add unit test verifying custom config is applied
- Document the new parameter in WAR and OSGi agent configuration tables

Resolves the TODO in `PullNotificationBackend.init()` requesting a configuration parameter for `maxEntries`.

## Test plan

- [x] Existing `PullNotificationBackendTest` tests pass (5/5)
- [x] New `testCustomMaxEntries` verifies non-default value is reflected in `getConfig()`
- [x] `testConfig` now asserts default value `100` explicitly

Assisted-By: 🤖 Claude Code