### PR TITLE
Validate notificationMaxEntries and add JVM agent docs

### DIFF
--- a/service/notif/pull/src/main/java/org/jolokia/service/notif/pull/PullNotificationBackend.java
+++ b/service/notif/pull/src/main/java/org/jolokia/service/notif/pull/PullNotificationBackend.java
@@ -52,10 +52,12 @@ public class PullNotificationBackend extends AbstractJolokiaService<Notification
     }
 
     private int getMaxEntries(JolokiaContext pCtx) {
+        int fallback = Integer.parseInt(ConfigKey.NOTIFICATION_MAX_ENTRIES.getDefaultValue());
         try {
-            return Integer.parseInt(pCtx.getConfig(ConfigKey.NOTIFICATION_MAX_ENTRIES));
+            int value = Integer.parseInt(pCtx.getConfig(ConfigKey.NOTIFICATION_MAX_ENTRIES));
+            return value > 0 ? value : fallback;
         } catch (NumberFormatException exp) {
-            return Integer.parseInt(ConfigKey.NOTIFICATION_MAX_ENTRIES.getDefaultValue());
+            return fallback;
         }
     }
 

--- a/service/notif/pull/src/test/java/org/jolokia/service/notif/pull/PullNotificationBackendTest.java
+++ b/service/notif/pull/src/test/java/org/jolokia/service/notif/pull/PullNotificationBackendTest.java
@@ -80,6 +80,40 @@ public class PullNotificationBackendTest {
         }
     }
 
+    @Test
+    public void testInvalidMaxEntriesFallsBackToDefault() throws Exception {
+        TestJolokiaContext customContext = new TestJolokiaContext.Builder()
+                .config(ConfigKey.AGENT_ID, "test-invalid",
+                        ConfigKey.NOTIFICATION_MAX_ENTRIES, "not-a-number")
+                .build();
+        PullNotificationBackend customBackend = new PullNotificationBackend(0);
+        try {
+            customBackend.init(customContext);
+            JSONObject cfg = (JSONObject) customBackend.getConfig();
+            Assert.assertEquals(cfg.get("maxEntries"), 100);
+        } finally {
+            customBackend.destroy();
+            customContext.destroy();
+        }
+    }
+
+    @Test
+    public void testZeroMaxEntriesFallsBackToDefault() throws Exception {
+        TestJolokiaContext customContext = new TestJolokiaContext.Builder()
+                .config(ConfigKey.AGENT_ID, "test-zero",
+                        ConfigKey.NOTIFICATION_MAX_ENTRIES, "0")
+                .build();
+        PullNotificationBackend customBackend = new PullNotificationBackend(0);
+        try {
+            customBackend.init(customContext);
+            JSONObject cfg = (JSONObject) customBackend.getConfig();
+            Assert.assertEquals(cfg.get("maxEntries"), 100);
+        } finally {
+            customBackend.destroy();
+            customContext.destroy();
+        }
+    }
+
    @Test
    public void testSubscription() throws Exception {
        String client = UUID.randomUUID().toString();

--- a/src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc
@@ -363,6 +363,11 @@ network traffic. Nevertheless, when set to 0
 no limit is imposed.
 |Default: `0`
 
+|`notificationMaxEntries`
+|Maximum number of entries to keep per notification
+subscription in the pull notification store.
+|Default: `100`
+
 |`serializeLong`
 |How to serialize long values in the JSON response: `number` or `string`.
 The default `number` simply serializes longs as numbers in JSON.


### PR DESCRIPTION
## Summary

Follow-up to #1052:

- Guard against zero/negative `notificationMaxEntries` values that would cause `NoSuchElementException` in `NotificationStore.add()` when the entry set is empty
- Add tests for invalid (non-numeric) and zero config values
- Document `notificationMaxEntries` in the JVM agent configuration table

## Test plan

- [x] `testInvalidMaxEntriesFallsBackToDefault` verifies non-numeric config falls back to default 100
- [x] `testZeroMaxEntriesFallsBackToDefault` verifies zero config falls back to default 100
- [x] All 7 `PullNotificationBackendTest` tests pass

Assisted-By: 🤖 Claude Code